### PR TITLE
Remove list idiom class and example sentence

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ fn main() {
             for description in word.descriptions {
                 println!("品詞: {:?}", description.part());
                 println!("{}", description.text());
-                println!("========================================================")
             }
         }
         Err(err) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -44,10 +44,10 @@ pub fn my_parse_docment(docment: String) -> Result<Word, Box<dyn std::error::Err
                 continue;
             }
             let li_element = ElementRef::wrap(li_node).unwrap();
-            let text = li_element.text().collect::<Vec<_>>();
-            println!("{:?}", text);
-            let text = text.join("");
-            description += &text;
+            let text: String = li_element.text().take_while(|&s| !s.eq("\n")).collect();
+            let text = text.trim();
+            description += text;
+            description += "\n";
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -13,32 +13,29 @@ pub fn my_parse_docment(docment: String) -> Result<Word, Box<dyn std::error::Err
 
     for ol_element in ol_list {
         // list-data-bクラスに必要なデータが記載されているのでそれ以外はスルー
-        let has_list_data_class = ol_element.value().classes().any(|s| s.eq("list-data-b"));
-        if !has_list_data_class {
+        let has_list_meanings_class = ol_element.value().classes().any(|s| s.eq("list-meanings"));
+        if !has_list_meanings_class {
             continue;
         }
 
         // ol要素にはlist-meaningsクラスとlist-idiomクラスのどちらかが付与されているので、
         // もしもlist-meaningsクラスが付与されていた場合は、兄要素に記載されている品詞の情報も取得しておく
-        let has_list_meanings_class = ol_element.value().classes().any(|s| s.eq("list-meanings"));
-        if has_list_meanings_class {
-            if let Some(p) = part {
-                word.push(p, description.to_string());
+        if let Some(p) = part {
+            word.push(p, description.to_string());
+        }
+        match ol_element
+            .prev_siblings()
+            .find(|node| node.value().is_element())
+        {
+            Some(prev_sibling) => {
+                let prev_sibling = ElementRef::wrap(prev_sibling).unwrap();
+                if let Ok(p) = Part::try_from(prev_sibling) {
+                    part = Some(p);
+                    description = String::new();
+                }
             }
-            match ol_element
-                .prev_siblings()
-                .find(|node| node.value().is_element())
-            {
-                Some(prev_sibling) => {
-                    let prev_sibling = ElementRef::wrap(prev_sibling).unwrap();
-                    if let Ok(p) = Part::try_from(prev_sibling) {
-                        part = Some(p);
-                        description = String::new();
-                    }
-                }
-                None => {
-                    unreachable!();
-                }
+            None => {
+                unreachable!();
             }
         }
 
@@ -47,7 +44,9 @@ pub fn my_parse_docment(docment: String) -> Result<Word, Box<dyn std::error::Err
                 continue;
             }
             let li_element = ElementRef::wrap(li_node).unwrap();
-            let text = li_element.text().collect::<String>();
+            let text = li_element.text().collect::<Vec<_>>();
+            println!("{:?}", text);
+            let text = text.join("");
             description += &text;
         }
     }


### PR DESCRIPTION
- HTML構造が複雑で、意味・例文・イディオムの三種類を綺麗にパースするのが難しい
- パースできたとしても、データベースで管理するのも難しそう
- そもそも単語帳として使う時に、こんなに情報は必要なさそう

ということで、パースする時に例文とイディオムをばっさりカットした

# Before
```
品詞: Noun
1 乳，母乳，（特に）牛乳

first milk初乳
cow's milk牛乳
a bottle of milk１びんのミルク
(as) white as milkまっ白な
a cow in milk乳の出ている牛
milk mustache牛乳でつけた上くちびるの白い筋
2 乳状の液，（植物の）樹乳，乳液

milk of lime石灰乳

cry over spilled [spilt] milk
過ぎたことを悔む

get [come] home with the milk
((英俗))（夜どおし騒いだあと）朝帰りする

milk and honey
乳とみつ；豊かな生活のかて

milk and water
1 水で割った牛乳
2 気の抜けた話
3 めそめそした感情

milk for babes [babies]
子ども向きの本［説教］

the milk in the coconut
((俗))物事の核心，要点

the milk of human kindness
((形式))心の優しさ（◆Shakespeare より）

========================================================
品詞: Verb
1 他自〈牛などの〉乳をしぼる

milk a cow [a goat]牛［ヤギ］の乳をしぼる
1a 他〈乳を〉（動物から）しぼる1b 自〈牛などが〉乳を出す1c 他〈動物・植物などの〉（毒・体液・樹液などを）しぼり出す≪of≫；他〈樹液・体液・毒などを〉（動物・植物などから）しぼり出す≪from≫2 他((略式))…を食いものにする，〈人から〉（金・情報などを）しぼり取る，引き出す≪of，for≫；〈金・情報などを〉（人などから）引き出す≪out of≫

milk an enterprise事業を食いものにする
milk a person for information人から情報を聞き出す
milk ... for all its worth…を最大限に利用する

========================================================
```
# After
```
品詞: Noun
1 乳，母乳，（特に）牛乳
2 乳状の液，（植物の）樹乳，乳液

品詞: Verb
1 他自〈牛などの〉乳をしぼる
1a 他〈乳を〉（動物から）しぼる
1b 自〈牛などが〉乳を出す
1c 他〈動物・植物などの〉（毒・体液・樹液などを）しぼり出す≪of≫；他〈樹液・体液・毒などを〉（動物・植物などから）しぼり出す≪from≫
2 他((略式))…を食いものにする，〈人から〉（金・情報などを）しぼり取る，引き出す≪of，for≫；〈金・情報などを〉（人などから）引き出す≪out of≫
```