### PR TITLE
Remove the index of meanings

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,6 +21,7 @@ pub fn my_parse_docment(docment: String) -> Result<Word, Box<dyn std::error::Err
             let li_elem = ElementRef::wrap(li_node).unwrap();
             let mut text: String = li_elem
                 .text()
+                .skip(1)
                 .take_while(|&s| !s.eq("\n"))
                 .map(|s| s.trim())
                 .collect();


### PR DESCRIPTION
before
```
品詞: Noun
1 乳，母乳，（特に）牛乳
2 乳状の液，（植物の）樹乳，乳液

品詞: Verb
1 他自〈牛などの〉乳をしぼる
1a 他〈乳を〉（動物から）しぼる
1b 自〈牛などが〉乳を出す
1c 他〈動物・植物などの〉（毒・体液・樹液などを）しぼり出す≪of≫；他〈樹液・体液・毒などを〉（動物・植物などから）しぼり出す≪from≫
2 他((略式))…を食いものにする，〈人から〉（金・情報などを）しぼり取る，引き出す≪of，for≫；〈金・情報などを〉（人などから）引き出す≪out of≫
```

after
```
品詞: Noun
乳，母乳，（特に）牛乳
乳状の液，（植物の）樹乳，乳液

品詞: Verb
他自〈牛などの〉乳をしぼる
他〈乳を〉（動物から）しぼる
自〈牛などが〉乳を出す
他〈動物・植物などの〉（毒・体液・樹液などを）しぼり出す≪of≫；他〈樹液・体液・毒などを〉（動物・植物などから）しぼり出す≪from≫
他((略式))…を食いものにする，〈人から〉（金・情報などを）しぼり取る，引き出す≪of，for≫；〈金・情報などを〉（人などから）引き出す≪out of≫
```