### PR TITLE
Update wrap_hinshi function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+path = "src/lib.rs"
 
 [dependencies]
 scraper = "0.12.0"

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,2 +1,4 @@
-pub(crate) const INTRANSITIVE_VERB: &str = "[自]";
-pub(crate) const TRANSITIVE_VERB: &str = "[他]";
+pub(crate) const INTRANSITIVE_VERB: &str = "[自]"; // 自動詞
+pub(crate) const TRANSITIVE_VERB: &str = "[他]"; // 他動詞
+pub(crate) const COUNTABLE_NOUN: &str = "[C]"; // 可算名詞
+pub(crate) const UNCOUNTABLE_NOUN: &str = "[U]"; // 不可算名詞

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,7 +11,7 @@ pub fn parse(docment: String) -> Result<Word, Box<dyn std::error::Error>> {
 
     for ol_elem in ol_list {
         // ol_elemの兄要素に単語の品詞情報が含まれているので抽出する
-        let part = get_part(&ol_elem).expect("Failed to get part");
+        let part = get_part(&ol_elem)?;
         let mut description = String::new();
 
         for li_node in ol_elem.children() {
@@ -51,6 +51,8 @@ fn wrap_hinshi(s: &str) -> &str {
     match s {
         "自" => consts::INTRANSITIVE_VERB,
         "他" => consts::TRANSITIVE_VERB,
+        "C" => consts::COUNTABLE_NOUN,
+        "U" => consts::UNCOUNTABLE_NOUN,
         _ => s,
     }
 }


### PR DESCRIPTION
加算名詞・不可算名詞の品詞情報をパースできるようにした
#6 

before
```
品詞: Noun
C（川などの）水源，源流；《力学》（流体の）わき出し
C（発光・発射などの）源
C（問題などの）根本，原因，元
C（物・事の）源，供給源，根源，出所；情報源，消息筋，出典，典拠（[連語]動＋source：〔提供〕offer/provide/act as；〔発見〕discover/identify/locate/access；〔発生〕stem from/originate from/derive from）
C《植物》ソース（◇高等植物の有機物を生産する光合成器官），《工学》供給源（◇原料などを供給・発生する場所・材料など），《電子工学》ソース（◇電界効果トランジスタでキャリアを供給する電極・端子）；U《コンピュ》ソースコード（source code）（◇この指示に基づきコンピュータが動作する）
```
after
```
品詞: Noun
[C]（川などの）水源，源流；《力学》（流体の）わき出し
[C]（発光・発射などの）源
[C]（問題などの）根本，原因，元
[C]（物・事の）源，供給源，根源，出所；情報源，消息筋，出典，典拠（[連語]動＋source：〔提供〕offer/provide/act as；〔発見〕discover/identify/locate/access；〔発生〕stem from/originate from/derive from）
[C]《植物》ソース（◇高等植物の有機物を生産する光合成器官），《工学》供給源（◇原料などを供給・発生する場所・材料など），《電子工学》ソース（◇電界効果トランジスタでキャリアを供給する電極・端子）；[U]《コンピュ》ソースコード（source code）（◇この指示に基づきコンピュータが動作する）
```